### PR TITLE
Fix Windows shell call for Ollama

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -57,8 +57,9 @@ def polish_with_ollama(feet_lines):
         cmd = [OLLAMA_EXE, "run", OLLAMA_IMAGE]
     else:
         # Windows fallback via PowerShell
-        script = f"echo \"{prompt.replace('\"', '`\"')}\" | ollama run {OLLAMA_IMAGE}"
-        cmd = [OLLAMA_EXE, "/c", script]
+        safe_prompt = prompt.replace('"', '`"')
+        script = f'echo "{safe_prompt}" | ollama run {OLLAMA_IMAGE}'
+        cmd = [OLLAMA_EXE, "-Command", script]
 
     print(f"[🚀] Running: {' '.join(cmd)}")
 

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ The `data_preparation/` folder includes:
 * Uses `rapidfuzz` or `fuzzywuzzy` for matching
 * Uses `scipy.spatial.KDTree` for nearest-node snapping
 * Tested on WSL with Python 3.10 and 3.12
-* If Ollama is installed only in Windows, WSL calls it via PowerShell
+* If Ollama is installed only in Windows, WSL calls it via PowerShell using `-Command`
 
 ---
 


### PR DESCRIPTION
## Summary
- correct PowerShell arguments used when calling Ollama
- document the PowerShell command flag in README

## Testing
- `python3 -m py_compile app/app.py app/generate_directions_with_feet.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb7f2e79c832f8799c9254180894f